### PR TITLE
Feature/rtp

### DIFF
--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -26,16 +26,8 @@ object Common : ModInitializer {
         HomeCommand(dispatcher).register()
         HomesCommand(dispatcher).register()
         SetHomeCommand(dispatcher).register()
-
-        // TPA commands
-        TpaCommand(dispatcher).register()
-        TpaHereCommand(dispatcher).register()
-        TpAcceptCommand(dispatcher).register()
-        TpCancelCommand(dispatcher).register()
-        TpDenyCommand(dispatcher).register()
         
         // Teleport commands
-        BackCommand(dispatcher).register()
         RtpCommand(dispatcher).register()
 
         // Misc commands

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -2,6 +2,7 @@ package me.gserv.fabrikommander
 
 import me.gserv.fabrikommander.commands.*
 import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.SpawnDataManager
 import me.gserv.fabrikommander.utils.Dispatcher
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
@@ -13,6 +14,7 @@ object Common : ModInitializer {
 
     override fun onInitialize() {
         PlayerDataManager.setup()
+        SpawnDataManager.setup()
 
         CommandRegistrationCallback.EVENT.register(::registerCommands)
     }
@@ -27,7 +29,18 @@ object Common : ModInitializer {
         HomesCommand(dispatcher).register()
         SetHomeCommand(dispatcher).register()
 
-        // Misc comands
+        // TPA commands
+        TpaCommand(dispatcher).register()
+        TpaHereCommand(dispatcher).register()
+        TpAcceptCommand(dispatcher).register()
+        TpCancelCommand(dispatcher).register()
+        TpDenyCommand(dispatcher).register()
+        
+        // Teleport commands
+        BackCommand(dispatcher).register()
+        RtpCommand(dispatcher).register()
+
+        // Misc commands
         PingCommand(dispatcher).register()
     }
 }

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -2,7 +2,6 @@ package me.gserv.fabrikommander
 
 import me.gserv.fabrikommander.commands.*
 import me.gserv.fabrikommander.data.PlayerDataManager
-import me.gserv.fabrikommander.data.SpawnDataManager
 import me.gserv.fabrikommander.utils.Dispatcher
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
@@ -14,7 +13,6 @@ object Common : ModInitializer {
 
     override fun onInitialize() {
         PlayerDataManager.setup()
-        SpawnDataManager.setup()
 
         CommandRegistrationCallback.EVENT.register(::registerCommands)
     }

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -1,0 +1,93 @@
+package me.gserv.fabrikommander.commands
+
+import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.Context
+import me.gserv.fabrikommander.utils.Dispatcher
+import me.gserv.fabrikommander.utils.gold
+import me.gserv.fabrikommander.utils.gray
+import me.gserv.fabrikommander.utils.yellow
+import me.gserv.fabrikommander.utils.plus
+import me.gserv.fabrikommander.utils.aqua
+import net.minecraft.server.command.CommandManager
+import net.minecraft.util.Identifier
+import net.minecraft.server.world.ServerWorld
+import net.minecraft.util.registry.Registry
+import net.minecraft.util.registry.RegistryKey
+import net.minecraft.util.math.BlockPos
+
+class RtpCommand(val dispatcher: Dispatcher) {
+    private val rtpRange = -5000..5000
+
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("rtp")
+                .executes { rtpCommand(it) }
+        )
+        dispatcher.register(
+            CommandManager.literal("wild")
+                .executes { rtpCommand(it) }
+        )
+    }
+    
+    private fun generateCoordinates(world: ServerWorld?): List<Int> {
+        val x = rtpRange.random()
+        val z = rtpRange.random()
+        val y = getHighestBlock(world, x, z)
+
+        if (world?.isWater(BlockPos(x, y, z)) == true) {
+            return generateCoordinates(world)
+        }
+
+        return listOf(x, y + 1, z)
+    }
+
+    private fun getHighestBlock(world: ServerWorld?, x: Int, z: Int): Int {
+        val heightLimit = world!!.heightLimit
+
+        for (height in heightLimit downTo 0)
+            if (!world.isAir(BlockPos(x, height, z))) {
+                return height
+            }
+
+        return 0
+    }
+
+    fun rtpCommand(context: Context): Int {
+        val player = context.source.player
+        val overworld = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, Identifier("minecraft:overworld")))
+        val coordinates = generateCoordinates(overworld)
+
+        PlayerDataManager.setBackPos(
+            player.uuid,
+            Pos(
+                x = player.x,
+                y = player.y,
+                z = player.z,
+                world = player.world.registryKey.value,
+                yaw = player.yaw,
+                pitch = player.pitch
+            )
+        )
+
+        player.teleport(
+            overworld,
+            coordinates[0].toDouble(),
+            coordinates[1].toDouble(),
+            coordinates[2].toDouble(),
+            player.yaw,
+            player.pitch
+        )
+        context.source.sendFeedback(
+            gray("[") +
+            yellow("RTP") +
+            gray("] ") +
+            gold("Randomly teleported to ") +
+            aqua("[${player.x.toInt()}, ${player.y.toInt()}, ${player.z.toInt()}]"),
+            true
+        )
+        
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -1,6 +1,5 @@
 package me.gserv.fabrikommander.commands
 
-import me.gserv.fabrikommander.data.PlayerDataManager
 import me.gserv.fabrikommander.data.spec.Pos
 import me.gserv.fabrikommander.utils.Context
 import me.gserv.fabrikommander.utils.Dispatcher
@@ -58,18 +57,6 @@ class RtpCommand(val dispatcher: Dispatcher) {
         val overworld = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, Identifier("minecraft:overworld")))
         val coordinates = generateCoordinates(overworld)
 
-        PlayerDataManager.setBackPos(
-            player.uuid,
-            Pos(
-                x = player.x,
-                y = player.y,
-                z = player.z,
-                world = player.world.registryKey.value,
-                yaw = player.yaw,
-                pitch = player.pitch
-            )
-        )
-
         player.teleport(
             overworld,
             coordinates[0].toDouble(),
@@ -78,6 +65,7 @@ class RtpCommand(val dispatcher: Dispatcher) {
             player.yaw,
             player.pitch
         )
+        
         context.source.sendFeedback(
             gray("[") +
             yellow("RTP") +

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -28,7 +28,7 @@ class RtpCommand(val dispatcher: Dispatcher) {
         )
     }
     
-    private fun generateCoordinates(world: ServerWorld?): List<Int> {
+    private fun generateCoordinates(world: ServerWorld?): List<Double> {
         val x = rtpRange.random()
         val z = rtpRange.random()
         val y = getHighestBlock(world, x, z)
@@ -37,7 +37,7 @@ class RtpCommand(val dispatcher: Dispatcher) {
             return generateCoordinates(world)
         }
 
-        return listOf(x, y + 1, z)
+        return listOf(x + 0.5, y + 1.0, z + 0.5)
     }
 
     private fun getHighestBlock(world: ServerWorld?, x: Int, z: Int): Int {
@@ -58,9 +58,9 @@ class RtpCommand(val dispatcher: Dispatcher) {
 
         player.teleport(
             overworld,
-            coordinates[0].toDouble(),
-            coordinates[1].toDouble(),
-            coordinates[2].toDouble(),
+            coordinates[0],
+            coordinates[1],
+            coordinates[2],
             player.yaw,
             player.pitch
         )

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/RtpCommand.kt
@@ -1,6 +1,5 @@
 package me.gserv.fabrikommander.commands
 
-import me.gserv.fabrikommander.data.spec.Pos
 import me.gserv.fabrikommander.utils.Context
 import me.gserv.fabrikommander.utils.Dispatcher
 import me.gserv.fabrikommander.utils.gold


### PR DESCRIPTION
This is not entirely completed as I'd like to add a few things:
 - /rtprange (currently 5k radius is hardcoded)
 - /rtpcenter (currently only uses the center of the world `0 0`)
 - /rtptimeout (currently there is none, but I'd also like to add a time out to using this command because the chunk loading can cause lag)

~~`RtpCommand.kt` calls the method `PlayerDataManager.setBackPos` on line 61, which uses the back feature of @YTG1234's PR.~~ this has been removed