### PR TITLE
Feature/spawn

### DIFF
--- a/src/main/java/me/gserv/fabrikommander/mixin/PlayerManagerMixin.java
+++ b/src/main/java/me/gserv/fabrikommander/mixin/PlayerManagerMixin.java
@@ -1,16 +1,74 @@
 package me.gserv.fabrikommander.mixin;
 
 import me.gserv.fabrikommander.data.PlayerDataManager;
+import me.gserv.fabrikommander.data.SpawnDataManager;
+import me.gserv.fabrikommander.data.spec.Spawn;
 import net.minecraft.network.ClientConnection;
+import net.minecraft.network.Packet;
+import net.minecraft.network.packet.s2c.play.PlayerListHeaderS2CPacket;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.util.Util;
+import net.minecraft.util.WorldSavePath;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import java.io.File;
+import java.io.FilenameFilter;
+
+import static me.gserv.fabrikommander.utils.TextKt.*;
+import static me.gserv.fabrikommander.utils.TextFormatterKt.*;
 
 @Mixin(PlayerManager.class)
 public class PlayerManagerMixin {
+    private Boolean isNewPlayer(ServerPlayerEntity player) {
+        String uuid = player.getUuidAsString();
+        FilenameFilter filter = new FilenameFilter() {
+            @Override
+            public boolean accept(File file, String name) {
+                return name.endsWith(".dat");
+            }
+        };
+        File dataDir = player.server.getSavePath(WorldSavePath.ROOT).resolve("playerdata").toFile();
+        File[] files = dataDir.listFiles(filter);
+        for (File file : files) {
+            if (file.getName().equals(uuid + ".dat")) { return false; }
+        }
+        return true;
+    }
+
+    @Inject(at = @At("RETURN"), method = "onPlayerConnect")
+    private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
+        PlayerDataManager.INSTANCE.playerJoined(player);
+
+        // Welcome new player and teleport them to spawn
+        if (isNewPlayer(player)) {
+            Spawn spawn = SpawnDataManager.INSTANCE.getSpawn();
+            ServerWorld spawnWorld = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, spawn.getPos().getWorld()));
+            MutableText welcomeMessage = aqua("Welcome ").append(
+                    gray((MutableText) player.getDisplayName())
+            );
+            PlayerLookup.all(player.getServer()).forEach(p->p.sendSystemMessage(welcomeMessage, Util.NIL_UUID));
+            player.teleport(
+                    spawnWorld,
+                    spawn.getPos().getX(),
+                    spawn.getPos().getY(),
+                    spawn.getPos().getZ(),
+
+                    spawn.getPos().getYaw(),
+                    spawn.getPos().getPitch()
+            );
+        }
+    }
+    
     @Inject(at = @At("RETURN"), method = "onPlayerConnect")
     private void onPlayerConnect(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
         PlayerDataManager.INSTANCE.playerJoined(player);

--- a/src/main/kotlin/me/gserv/fabrikommander/Common.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/Common.kt
@@ -2,6 +2,7 @@ package me.gserv.fabrikommander
 
 import me.gserv.fabrikommander.commands.*
 import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.SpawnDataManager
 import me.gserv.fabrikommander.utils.Dispatcher
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback
@@ -13,6 +14,7 @@ object Common : ModInitializer {
 
     override fun onInitialize() {
         PlayerDataManager.setup()
+        SpawnDataManager.setup()
 
         CommandRegistrationCallback.EVENT.register(::registerCommands)
     }
@@ -26,6 +28,10 @@ object Common : ModInitializer {
         HomeCommand(dispatcher).register()
         HomesCommand(dispatcher).register()
         SetHomeCommand(dispatcher).register()
+        
+        // Teleport commands
+        SpawnCommand(dispatcher).register()
+        SetSpawnCommand(dispatcher).register()
 
         // Misc comands
         PingCommand(dispatcher).register()

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/SetSpawnCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/SetSpawnCommand.kt
@@ -1,0 +1,44 @@
+package me.gserv.fabrikommander.commands
+
+import me.gserv.fabrikommander.data.SpawnDataManager
+import me.gserv.fabrikommander.data.spec.Spawn
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.*
+import net.minecraft.server.command.CommandManager
+
+class SetSpawnCommand(val dispatcher: Dispatcher) {
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("setspawn")
+                .executes { setSpawnCommand(it) }
+                .requires { it.hasPermissionLevel(2) }
+        )
+    }
+
+    fun setSpawnCommand(context: Context): Int {
+        val player = context.source.player
+
+        val spawn = Spawn(
+            pos = Pos(
+                x = player.x,
+                y = player.y,
+                z = player.z,
+                yaw = player.yaw,
+                pitch = player.pitch,
+                world = player.world.registryKey.value
+            ),
+        )
+
+        SpawnDataManager.setSpawn(spawn)
+
+        context.source.sendFeedback(
+            green("Spawn created at ") +
+                    aqua("[${player.x.toInt()}, ${player.y.toInt()}, ${player.z.toInt()}]") +
+                    green(" in the ") +
+                    aqua(identifierToWorldName(player.world.registryKey.value)),
+            true
+        )
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
@@ -2,8 +2,6 @@ package me.gserv.fabrikommander.commands
 
 import com.mojang.brigadier.arguments.StringArgumentType
 import me.gserv.fabrikommander.data.SpawnDataManager
-import me.gserv.fabrikommander.data.PlayerDataManager
-import me.gserv.fabrikommander.data.spec.Pos
 import me.gserv.fabrikommander.utils.Context
 import me.gserv.fabrikommander.utils.Dispatcher
 import me.gserv.fabrikommander.utils.aqua
@@ -42,17 +40,6 @@ class SpawnCommand(val dispatcher: Dispatcher) {
                 false
             )
         } else {
-            PlayerDataManager.setBackPos(
-                player.uuid,
-                Pos(
-                    x = player.x,
-                    y = player.y,
-                    z = player.z,
-                    world = player.world.registryKey.value,
-                    yaw = player.yaw,
-                    pitch = player.pitch
-                )
-            )
 
             player.teleport(world, spawn.pos.x, spawn.pos.y, spawn.pos.z, spawn.pos.yaw, spawn.pos.pitch)
 

--- a/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/commands/SpawnCommand.kt
@@ -1,0 +1,67 @@
+package me.gserv.fabrikommander.commands
+
+import com.mojang.brigadier.arguments.StringArgumentType
+import me.gserv.fabrikommander.data.SpawnDataManager
+import me.gserv.fabrikommander.data.PlayerDataManager
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.utils.Context
+import me.gserv.fabrikommander.utils.Dispatcher
+import me.gserv.fabrikommander.utils.aqua
+import me.gserv.fabrikommander.utils.green
+import me.gserv.fabrikommander.utils.identifierToWorldName
+import me.gserv.fabrikommander.utils.plus
+import me.gserv.fabrikommander.utils.red
+import me.gserv.fabrikommander.utils.yellow
+import net.minecraft.server.command.CommandManager
+import net.minecraft.util.registry.Registry
+import net.minecraft.util.registry.RegistryKey
+
+class SpawnCommand(val dispatcher: Dispatcher) {
+    fun register() {
+        dispatcher.register(
+            CommandManager.literal("spawn")
+                .executes { spawnCommand(it) }
+        )
+    }
+
+    fun spawnCommand(context: Context): Int {
+        val player = context.source.player
+        val spawn = SpawnDataManager.getSpawn()
+
+        val world = player.server.getWorld(RegistryKey.of(Registry.DIMENSION, spawn.pos.world))
+
+        if (world == null) {
+            context.source.sendFeedback(
+                red("Warp ") +
+                        aqua("spawn") +
+                        red(" is in a world ") +
+                        yellow("(") +
+                        aqua(identifierToWorldName(spawn.pos.world)) +
+                        yellow(") ") +
+                        red("that no longer exists."),
+                false
+            )
+        } else {
+            PlayerDataManager.setBackPos(
+                player.uuid,
+                Pos(
+                    x = player.x,
+                    y = player.y,
+                    z = player.z,
+                    world = player.world.registryKey.value,
+                    yaw = player.yaw,
+                    pitch = player.pitch
+                )
+            )
+
+            player.teleport(world, spawn.pos.x, spawn.pos.y, spawn.pos.z, spawn.pos.yaw, spawn.pos.pitch)
+
+            context.source.sendFeedback(
+                green("Teleported to spawn!"),
+                true
+            )
+        }
+
+        return 1
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/data/SpawnDataManager.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/SpawnDataManager.kt
@@ -1,0 +1,80 @@
+package me.gserv.fabrikommander.data
+
+import com.charleskorn.kaml.Yaml
+import me.gserv.fabrikommander.data.spec.Player
+import me.gserv.fabrikommander.data.spec.Pos
+import me.gserv.fabrikommander.data.spec.Spawn
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents
+import net.minecraft.util.Identifier
+import net.minecraft.util.WorldSavePath
+import org.apache.logging.log4j.LogManager
+import java.nio.file.Path
+import kotlin.NoSuchElementException
+
+object SpawnDataManager {
+    private val logger = LogManager.getLogger(this::class.java)
+
+    private lateinit var dataDir: Path
+
+    fun setup() {
+        ServerLifecycleEvents.SERVER_STARTING.register {
+            dataDir = it.getSavePath(WorldSavePath.ROOT).resolve("FabriKommander")
+
+            dataDir.toFile().mkdir()
+
+            logger.info("Data directory: $dataDir")
+        }
+    }
+
+    fun loadData(): Spawn {
+        val spawnFile = dataDir.resolve("spawn.yaml").toFile()
+
+        if (!spawnFile.exists()) {
+            spawnFile.createNewFile()
+
+            val data = Spawn(pos = Pos(
+                0.0,
+                75.0,
+                0.0,
+
+                0F,
+                0F,
+
+                Identifier("minecraft:overworld")
+            ))
+
+            spawnFile.writeText(
+                Yaml.default.encodeToString(Spawn.serializer(), data)
+            )
+
+            return data
+        }
+
+        val string = spawnFile.readText()
+        return Yaml.default.decodeFromString(Spawn.serializer(), string)
+    }
+
+    fun setSpawn(spawn: Spawn): Boolean? {
+        saveData(spawn)
+
+        return true
+    }
+
+
+    fun getSpawn(): Spawn {
+        return loadData()
+    }
+
+    fun saveData(spawn: Spawn) {
+        val spawnFile = dataDir.resolve("spawn.yaml").toFile()
+            ?: throw NoSuchElementException("No spawn config found")
+
+        if (!spawnFile.exists()) {
+            spawnFile.createNewFile()
+        }
+
+        spawnFile.writeText(
+            Yaml.default.encodeToString(Spawn.serializer(), spawn)
+        )
+    }
+}

--- a/src/main/kotlin/me/gserv/fabrikommander/data/spec/Spawn.kt
+++ b/src/main/kotlin/me/gserv/fabrikommander/data/spec/Spawn.kt
@@ -1,0 +1,8 @@
+package me.gserv.fabrikommander.data.spec
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Spawn(
+    val pos: Pos
+)


### PR DESCRIPTION
Adds /spawn and /setspawn
Spawn position is defaulted to `0 75 0` in the overworld, but is easily changed by either the config file `spawn.yaml` or by using /setspawn and standing right where you want the new spawn point to be.

~~There is one more thing that I'd like to add, which is to make it whenever new players join the game, it teleports them to spawn immediately, so they are at the server spawn when they join the game.~~ *implemented*